### PR TITLE
Support for merge requests

### DIFF
--- a/cr-bot.js
+++ b/cr-bot.js
@@ -323,7 +323,7 @@ var CrBot = function Constructor(settings) {
     }
 
     CrBot.prototype._parseCodeReviewCommits = function(message) {
-        var pattern = new RegExp('git.kiwicollection.net\/kiwicollection\/([\\w-]*)\/(?:commit|blob)\/(\\w{40})');
+        var pattern = new RegExp('git\.kiwicollection\.net\/kiwicollection\/([\\w-]*)\/(?:commit|blob|merge_requests)\/(\\w{40}|\\d+)');
 
         var commits = [];
 


### PR DESCRIPTION
A minor change to regexp patter to support merge requests. This now writes a merge request id to a hash column. You can refactor this later with your plans to change DB structure.